### PR TITLE
disabled output of water props in steam convention

### DIFF
--- a/ThermoFun/Common/OutputWaterSteamConventionProp.cpp
+++ b/ThermoFun/Common/OutputWaterSteamConventionProp.cpp
@@ -7,20 +7,20 @@ namespace ThermoFun {
 
 auto OutputSteamConventionH2OProp (std::string filename, const WaterThermoState wt) -> void
 {
-    std::ofstream myfile;
-//    filename = Outputpath + filename;
-    myfile.open (filename, std::ios::app);
-    string c=",";
+//    std::ofstream myfile;
+////    filename = Outputpath + filename;
+//    myfile.open (filename, std::ios::app);
+//    string c=",";
 
-    if ( myfile.tellp() == 0 )
-    {
-        myfile <<"T,P,Cp,Cv,RHO,H,S,G,A,U,V\n";
-    }
+//    if ( myfile.tellp() == 0 )
+//    {
+//        myfile <<"T,P,Cp,Cv,RHO,H,S,G,A,U,V\n";
+//    }
 
-    myfile << wt.temperature << c << wt.pressure << c << wt.cp << c << wt.cv << c << wt.density << c <<
-              wt.enthalpy << c << wt.entropy << c << wt.gibbs << c << wt.helmholtz << c <<
-              wt.internal_energy << c << wt.volume << endl;
-    myfile.close();
+//    myfile << wt.temperature << c << wt.pressure << c << wt.cp << c << wt.cv << c << wt.density << c <<
+//              wt.enthalpy << c << wt.entropy << c << wt.gibbs << c << wt.helmholtz << c <<
+//              wt.internal_energy << c << wt.volume << endl;
+//    myfile.close();
 
 }
 


### PR DESCRIPTION
Problems with building with vc2015 line 15: h..\ThermoFun\Common\OutputWaterSteamConventionProp.cpp(15): error C2666: 'std::fpos<_Mbstatet>::operator ==': 3 overloads have similar conversions