### PR TITLE
Increment version to 0.4.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.9)
 
 # Set the name of the project
-project(ThermoFun VERSION 0.4.3 LANGUAGES CXX)
+project(ThermoFun VERSION 0.4.5 LANGUAGES CXX)
 
 # Set the cmake module path of the project
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")


### PR DESCRIPTION
The current version of ThermoFun is v0.4.4, but its CMakeLists.txt is 0.4.3. This pull request sets it to 0.4.5.